### PR TITLE
updated giphy api url

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -821,7 +821,7 @@ function gifListener() {
 
 function gifWidget() {
     var apikey = "AGOnLXwDOWiIu3oC7OMWNFsQCMAElFt4"
-    var queryUrl = "http://api.giphy.com/v1/gifs/random?api_key=" + apikey+ "&limit=1";
+    var queryUrl = "https://api.giphy.com/v1/gifs/random?api_key=" + apikey+ "&limit=1";
     getData(queryUrl, generateGifWidgetHtml, displayGifWidget); 
 }
 


### PR DESCRIPTION
just changed from http:// to https:// on queryUrl so that it would pull. Wasn't grabbing the gif because it wasnt secure. 